### PR TITLE
feat: 1:1 Note CRUD API

### DIFF
--- a/backend/src/main/java/io/anikoloutsos/manager_tools/exception/EngineerNotFoundException.java
+++ b/backend/src/main/java/io/anikoloutsos/manager_tools/exception/EngineerNotFoundException.java
@@ -2,7 +2,7 @@ package io.anikoloutsos.manager_tools.exception;
 
 import java.util.UUID;
 
-public class EngineerNotFoundException extends RuntimeException {
+public class EngineerNotFoundException extends ResourceNotFoundException {
 
     public EngineerNotFoundException(UUID id) {
         super("Engineer not found with id: " + id);

--- a/backend/src/main/java/io/anikoloutsos/manager_tools/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/io/anikoloutsos/manager_tools/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package io.anikoloutsos.manager_tools.exception;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -15,10 +16,16 @@ public class GlobalExceptionHandler {
 
     private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
-    @ExceptionHandler(EngineerNotFoundException.class)
+    @ExceptionHandler(ResourceNotFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
-    public ErrorResponse handleNotFound(EngineerNotFoundException ex) {
+    public ErrorResponse handleNotFound(ResourceNotFoundException ex) {
         return new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleUnreadable(HttpMessageNotReadableException ex) {
+        return new ErrorResponse(HttpStatus.BAD_REQUEST.value(), "Malformed request body");
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/backend/src/main/java/io/anikoloutsos/manager_tools/exception/NoteNotFoundException.java
+++ b/backend/src/main/java/io/anikoloutsos/manager_tools/exception/NoteNotFoundException.java
@@ -1,0 +1,10 @@
+package io.anikoloutsos.manager_tools.exception;
+
+import java.util.UUID;
+
+public class NoteNotFoundException extends ResourceNotFoundException {
+
+    public NoteNotFoundException(UUID id) {
+        super("Note not found with id: " + id);
+    }
+}

--- a/backend/src/main/java/io/anikoloutsos/manager_tools/exception/ResourceNotFoundException.java
+++ b/backend/src/main/java/io/anikoloutsos/manager_tools/exception/ResourceNotFoundException.java
@@ -1,0 +1,10 @@
+package io.anikoloutsos.manager_tools.exception;
+
+// Abstract to enforce domain-specific subtypes (e.g. EngineerNotFoundException).
+// All subtypes are automatically handled by GlobalExceptionHandler as 404.
+public abstract class ResourceNotFoundException extends RuntimeException {
+
+    protected ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/io/anikoloutsos/manager_tools/note/InstantToLocalDateConverter.java
+++ b/backend/src/main/java/io/anikoloutsos/manager_tools/note/InstantToLocalDateConverter.java
@@ -1,0 +1,26 @@
+package io.anikoloutsos.manager_tools.note;
+
+import jakarta.persistence.AttributeConverter;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+
+public class InstantToLocalDateConverter implements AttributeConverter<Instant, LocalDate> {
+
+    public static Instant toUtcMidnight(Instant instant) {
+        return instant.atZone(ZoneOffset.UTC).toLocalDate().atStartOfDay(ZoneOffset.UTC).toInstant();
+    }
+
+    @Override
+    public LocalDate convertToDatabaseColumn(Instant instant) {
+        if (instant == null) return null;
+        return instant.atZone(ZoneOffset.UTC).toLocalDate();
+    }
+
+    @Override
+    public Instant convertToEntityAttribute(LocalDate localDate) {
+        if (localDate == null) return null;
+        return localDate.atStartOfDay(ZoneOffset.UTC).toInstant();
+    }
+}

--- a/backend/src/main/java/io/anikoloutsos/manager_tools/note/Note.java
+++ b/backend/src/main/java/io/anikoloutsos/manager_tools/note/Note.java
@@ -1,0 +1,50 @@
+package io.anikoloutsos.manager_tools.note;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "notes")
+public class Note {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "engineer_id", nullable = false)
+    private UUID engineerId;
+
+    @Convert(converter = InstantToLocalDateConverter.class)
+    @Column(nullable = false)
+    private Instant date;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String body;
+
+    protected Note() {
+    }
+
+    public Note(UUID engineerId, Instant date, String body) {
+        this.engineerId = engineerId;
+        this.date = date;
+        this.body = body;
+    }
+
+    public UUID getId() { return id; }
+
+    public UUID getEngineerId() { return engineerId; }
+
+    public Instant getDate() { return date; }
+    public void setDate(Instant date) { this.date = date; }
+
+    public String getBody() { return body; }
+    public void setBody(String body) { this.body = body; }
+}

--- a/backend/src/main/java/io/anikoloutsos/manager_tools/note/NoteController.java
+++ b/backend/src/main/java/io/anikoloutsos/manager_tools/note/NoteController.java
@@ -1,0 +1,58 @@
+package io.anikoloutsos.manager_tools.note;
+
+import io.anikoloutsos.manager_tools.note.dto.CreateNoteRequest;
+import io.anikoloutsos.manager_tools.note.dto.NoteResponse;
+import io.anikoloutsos.manager_tools.note.dto.UpdateNoteRequest;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/engineers/{engineerId}/notes")
+public class NoteController {
+
+    private final NoteService service;
+
+    public NoteController(NoteService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public List<NoteResponse> getAll(@PathVariable UUID engineerId) {
+        return service.findAllByEngineerId(engineerId);
+    }
+
+    @GetMapping("/{id}")
+    public NoteResponse getById(@PathVariable UUID engineerId, @PathVariable UUID id) {
+        return service.findById(engineerId, id);
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public NoteResponse create(@PathVariable UUID engineerId, @RequestBody @Valid CreateNoteRequest request) {
+        return service.create(engineerId, request);
+    }
+
+    @PutMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void update(@PathVariable UUID engineerId, @PathVariable UUID id, @RequestBody @Valid UpdateNoteRequest request) {
+        service.update(engineerId, id, request);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable UUID engineerId, @PathVariable UUID id) {
+        service.delete(engineerId, id);
+    }
+}

--- a/backend/src/main/java/io/anikoloutsos/manager_tools/note/NoteRepository.java
+++ b/backend/src/main/java/io/anikoloutsos/manager_tools/note/NoteRepository.java
@@ -1,0 +1,13 @@
+package io.anikoloutsos.manager_tools.note;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface NoteRepository extends JpaRepository<Note, UUID> {
+
+    List<Note> findByEngineerIdOrderByDateDesc(UUID engineerId);
+}

--- a/backend/src/main/java/io/anikoloutsos/manager_tools/note/NoteService.java
+++ b/backend/src/main/java/io/anikoloutsos/manager_tools/note/NoteService.java
@@ -1,0 +1,21 @@
+package io.anikoloutsos.manager_tools.note;
+
+import io.anikoloutsos.manager_tools.note.dto.CreateNoteRequest;
+import io.anikoloutsos.manager_tools.note.dto.NoteResponse;
+import io.anikoloutsos.manager_tools.note.dto.UpdateNoteRequest;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface NoteService {
+
+    List<NoteResponse> findAllByEngineerId(UUID engineerId);
+
+    NoteResponse findById(UUID engineerId, UUID id);
+
+    NoteResponse create(UUID engineerId, CreateNoteRequest request);
+
+    void update(UUID engineerId, UUID id, UpdateNoteRequest request);
+
+    void delete(UUID engineerId, UUID id);
+}

--- a/backend/src/main/java/io/anikoloutsos/manager_tools/note/NoteServiceImpl.java
+++ b/backend/src/main/java/io/anikoloutsos/manager_tools/note/NoteServiceImpl.java
@@ -1,0 +1,91 @@
+package io.anikoloutsos.manager_tools.note;
+
+import io.anikoloutsos.manager_tools.engineer.EngineerRepository;
+import io.anikoloutsos.manager_tools.exception.EngineerNotFoundException;
+import io.anikoloutsos.manager_tools.exception.NoteNotFoundException;
+import io.anikoloutsos.manager_tools.note.dto.CreateNoteRequest;
+import io.anikoloutsos.manager_tools.note.dto.NoteResponse;
+import io.anikoloutsos.manager_tools.note.dto.UpdateNoteRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@Transactional
+public class NoteServiceImpl implements NoteService {
+
+    private final NoteRepository noteRepository;
+    private final EngineerRepository engineerRepository;
+
+    public NoteServiceImpl(NoteRepository noteRepository, EngineerRepository engineerRepository) {
+        this.noteRepository = noteRepository;
+        this.engineerRepository = engineerRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<NoteResponse> findAllByEngineerId(UUID engineerId) {
+        if (!engineerRepository.existsById(engineerId)) {
+            throw new EngineerNotFoundException(engineerId);
+        }
+        return noteRepository.findByEngineerIdOrderByDateDesc(engineerId).stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public NoteResponse findById(UUID engineerId, UUID id) {
+        if (!engineerRepository.existsById(engineerId)) {
+            throw new EngineerNotFoundException(engineerId);
+        }
+        Note note = noteRepository.findById(id)
+                .orElseThrow(() -> new NoteNotFoundException(id));
+        if (!note.getEngineerId().equals(engineerId)) {
+            throw new NoteNotFoundException(id);
+        }
+        return toResponse(note);
+    }
+
+    @Override
+    public NoteResponse create(UUID engineerId, CreateNoteRequest request) {
+        if (!engineerRepository.existsById(engineerId)) {
+            throw new EngineerNotFoundException(engineerId);
+        }
+        Note note = new Note(engineerId, InstantToLocalDateConverter.toUtcMidnight(request.date()), request.body());
+        return toResponse(noteRepository.save(note));
+    }
+
+    @Override
+    public void update(UUID engineerId, UUID id, UpdateNoteRequest request) {
+        if (!engineerRepository.existsById(engineerId)) {
+            throw new EngineerNotFoundException(engineerId);
+        }
+        Note note = noteRepository.findById(id)
+                .orElseThrow(() -> new NoteNotFoundException(id));
+        if (!note.getEngineerId().equals(engineerId)) {
+            throw new NoteNotFoundException(id);
+        }
+        note.setDate(InstantToLocalDateConverter.toUtcMidnight(request.date()));
+        note.setBody(request.body());
+    }
+
+    @Override
+    public void delete(UUID engineerId, UUID id) {
+        if (!engineerRepository.existsById(engineerId)) {
+            throw new EngineerNotFoundException(engineerId);
+        }
+        Note note = noteRepository.findById(id)
+                .orElseThrow(() -> new NoteNotFoundException(id));
+        if (!note.getEngineerId().equals(engineerId)) {
+            throw new NoteNotFoundException(id);
+        }
+        noteRepository.delete(note);
+    }
+
+    private NoteResponse toResponse(Note note) {
+        return new NoteResponse(note.getId(), note.getEngineerId(), note.getDate(), note.getBody());
+    }
+}

--- a/backend/src/main/java/io/anikoloutsos/manager_tools/note/dto/CreateNoteRequest.java
+++ b/backend/src/main/java/io/anikoloutsos/manager_tools/note/dto/CreateNoteRequest.java
@@ -1,0 +1,12 @@
+package io.anikoloutsos.manager_tools.note.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.Instant;
+
+public record CreateNoteRequest(
+        @NotNull Instant date,
+        @NotBlank String body
+) {
+}

--- a/backend/src/main/java/io/anikoloutsos/manager_tools/note/dto/NoteResponse.java
+++ b/backend/src/main/java/io/anikoloutsos/manager_tools/note/dto/NoteResponse.java
@@ -1,0 +1,12 @@
+package io.anikoloutsos.manager_tools.note.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record NoteResponse(
+        UUID id,
+        UUID engineerId,
+        Instant date,
+        String body
+) {
+}

--- a/backend/src/main/java/io/anikoloutsos/manager_tools/note/dto/UpdateNoteRequest.java
+++ b/backend/src/main/java/io/anikoloutsos/manager_tools/note/dto/UpdateNoteRequest.java
@@ -1,0 +1,12 @@
+package io.anikoloutsos.manager_tools.note.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.Instant;
+
+public record UpdateNoteRequest(
+        @NotNull Instant date,
+        @NotBlank String body
+) {
+}

--- a/backend/src/main/resources/db/migration/V2__create_notes_table.sql
+++ b/backend/src/main/resources/db/migration/V2__create_notes_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE notes (
+    id          UUID         NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+    engineer_id UUID         NOT NULL REFERENCES engineers(id) ON DELETE CASCADE,
+    date        DATE         NOT NULL,
+    body        TEXT         NOT NULL
+);
+
+CREATE INDEX idx_notes_engineer_id ON notes(engineer_id);

--- a/backend/src/test/java/io/anikoloutsos/manager_tools/note/NoteControllerIT.java
+++ b/backend/src/test/java/io/anikoloutsos/manager_tools/note/NoteControllerIT.java
@@ -1,0 +1,453 @@
+package io.anikoloutsos.manager_tools.note;
+
+import io.anikoloutsos.manager_tools.TestcontainersConfiguration;
+import io.anikoloutsos.manager_tools.engineer.Engineer;
+import io.anikoloutsos.manager_tools.engineer.EmploymentType;
+import io.anikoloutsos.manager_tools.engineer.EngineerLevel;
+import io.anikoloutsos.manager_tools.engineer.EngineerRepository;
+import io.anikoloutsos.manager_tools.engineer.Squad;
+import io.anikoloutsos.manager_tools.exception.ErrorResponse;
+import io.anikoloutsos.manager_tools.note.dto.CreateNoteRequest;
+import io.anikoloutsos.manager_tools.note.dto.NoteResponse;
+import io.anikoloutsos.manager_tools.note.dto.UpdateNoteRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.client.RestTestClient;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+class NoteControllerIT {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private NoteRepository noteRepository;
+
+    @Autowired
+    private EngineerRepository engineerRepository;
+
+    private RestTestClient client;
+
+    @BeforeEach
+    void setUp() {
+        client = RestTestClient.bindToApplicationContext(context).build();
+        noteRepository.deleteAll();
+        engineerRepository.deleteAll();
+    }
+
+    // --- GET /engineers/{engineerId}/notes ---
+
+    @Test
+    void getAll_returnsEmptyList_whenNoNotes() {
+        Engineer engineer = engineerRepository.save(buildEngineer());
+
+        client.get().uri("/engineers/" + engineer.getId() + "/notes")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(NoteResponse[].class)
+                .consumeWith(result -> assertThat(result.getResponseBody()).isEmpty());
+    }
+
+    @Test
+    void getAll_returnsNotesOrderedByDateDescending() {
+        Engineer engineer = engineerRepository.save(buildEngineer());
+        Instant older = LocalDate.of(2024, 1, 1).atStartOfDay(ZoneOffset.UTC).toInstant();
+        Instant newer = LocalDate.of(2024, 6, 1).atStartOfDay(ZoneOffset.UTC).toInstant();
+        noteRepository.save(new Note(engineer.getId(), older, "Older note"));
+        noteRepository.save(new Note(engineer.getId(), newer, "Newer note"));
+
+        client.get().uri("/engineers/" + engineer.getId() + "/notes")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(NoteResponse[].class)
+                .consumeWith(result -> {
+                    NoteResponse[] body = result.getResponseBody();
+                    assertThat(body).hasSize(2);
+                    assertThat(body[0].body()).isEqualTo("Newer note");
+                    assertThat(body[0].date()).isEqualTo(newer);
+                    assertThat(body[1].body()).isEqualTo("Older note");
+                    assertThat(body[1].date()).isEqualTo(older);
+                });
+    }
+
+    @Test
+    void getAll_returns404_whenEngineerNotFound() {
+        client.get().uri("/engineers/" + UUID.randomUUID() + "/notes")
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+    }
+
+    // --- GET /engineers/{engineerId}/notes/{id} ---
+
+    @Test
+    void getById_returnsNote_whenFound() {
+        Engineer engineer = engineerRepository.save(buildEngineer());
+        Instant date = LocalDate.of(2024, 3, 15).atStartOfDay(ZoneOffset.UTC).toInstant();
+        Note saved = noteRepository.save(new Note(engineer.getId(), date, "My note"));
+
+        client.get().uri("/engineers/" + engineer.getId() + "/notes/" + saved.getId())
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(NoteResponse.class)
+                .consumeWith(result -> {
+                    assertThat(result.getResponseBody().id()).isEqualTo(saved.getId());
+                    assertThat(result.getResponseBody().body()).isEqualTo("My note");
+                    assertThat(result.getResponseBody().engineerId()).isEqualTo(engineer.getId());
+                    assertThat(result.getResponseBody().date()).isEqualTo(date);
+                });
+    }
+
+    @Test
+    void getById_returns404_whenNoteNotFound() {
+        Engineer engineer = engineerRepository.save(buildEngineer());
+
+        client.get().uri("/engineers/" + engineer.getId() + "/notes/" + UUID.randomUUID())
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+    }
+
+    @Test
+    void getById_returns404_whenEngineerNotFound() {
+        client.get().uri("/engineers/" + UUID.randomUUID() + "/notes/" + UUID.randomUUID())
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+    }
+
+    // --- POST /engineers/{engineerId}/notes ---
+
+    @Test
+    void create_returns201_withNoteInResponse() {
+        Engineer engineer = engineerRepository.save(buildEngineer());
+        Instant date = LocalDate.of(2024, 5, 10).atStartOfDay(ZoneOffset.UTC).toInstant();
+        CreateNoteRequest request = new CreateNoteRequest(date, "Great progress this week");
+
+        client.post().uri("/engineers/" + engineer.getId() + "/notes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .exchange()
+                .expectStatus().isCreated()
+                .expectBody(NoteResponse.class)
+                .consumeWith(result -> {
+                    assertThat(result.getResponseBody().id()).isNotNull();
+                    assertThat(result.getResponseBody().engineerId()).isEqualTo(engineer.getId());
+                    assertThat(result.getResponseBody().body()).isEqualTo("Great progress this week");
+                    assertThat(result.getResponseBody().date()).isEqualTo(date);
+                });
+    }
+
+    @Test
+    void create_roundTrips_nonMidnightInstant_toUtcMidnight() {
+        Engineer engineer = engineerRepository.save(buildEngineer());
+        Instant nonMidnight = LocalDate.of(2024, 5, 10).atTime(14, 30).toInstant(ZoneOffset.UTC);
+        Instant expectedMidnight = LocalDate.of(2024, 5, 10).atStartOfDay(ZoneOffset.UTC).toInstant();
+
+        client.post().uri("/engineers/" + engineer.getId() + "/notes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(new CreateNoteRequest(nonMidnight, "Note with mid-day time"))
+                .exchange()
+                .expectStatus().isCreated()
+                .expectBody(NoteResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().date()).isEqualTo(expectedMidnight));
+    }
+
+    @Test
+    void create_returns404_whenEngineerNotFound() {
+        CreateNoteRequest request = new CreateNoteRequest(
+                LocalDate.of(2024, 5, 10).atStartOfDay(ZoneOffset.UTC).toInstant(),
+                "Some note"
+        );
+
+        client.post().uri("/engineers/" + UUID.randomUUID() + "/notes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+    }
+
+    @Test
+    void create_returns400_whenBodyIsBlank() {
+        Engineer engineer = engineerRepository.save(buildEngineer());
+        CreateNoteRequest request = new CreateNoteRequest(
+                LocalDate.of(2024, 5, 10).atStartOfDay(ZoneOffset.UTC).toInstant(),
+                ""
+        );
+
+        client.post().uri("/engineers/" + engineer.getId() + "/notes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .exchange()
+                .expectStatus().isBadRequest()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+    }
+
+    @Test
+    void create_returns400_whenDateIsNull() {
+        Engineer engineer = engineerRepository.save(buildEngineer());
+        CreateNoteRequest request = new CreateNoteRequest(null, "Some note");
+
+        client.post().uri("/engineers/" + engineer.getId() + "/notes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .exchange()
+                .expectStatus().isBadRequest()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+    }
+
+    @Test
+    void create_returns400_whenDateIsMalformed() {
+        Engineer engineer = engineerRepository.save(buildEngineer());
+
+        client.post().uri("/engineers/" + engineer.getId() + "/notes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Map.of("date", "not-a-timestamp", "body", "Some note"))
+                .exchange()
+                .expectStatus().isBadRequest()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+    }
+
+    // --- PUT /engineers/{engineerId}/notes/{id} ---
+
+    @Test
+    void update_returns204_andPersistsChanges() {
+        Engineer engineer = engineerRepository.save(buildEngineer());
+        Instant originalDate = LocalDate.of(2024, 1, 1).atStartOfDay(ZoneOffset.UTC).toInstant();
+        Note saved = noteRepository.save(new Note(engineer.getId(), originalDate, "Original body"));
+
+        Instant newDate = LocalDate.of(2024, 6, 1).atStartOfDay(ZoneOffset.UTC).toInstant();
+        UpdateNoteRequest request = new UpdateNoteRequest(newDate, "Updated body");
+
+        client.put().uri("/engineers/" + engineer.getId() + "/notes/" + saved.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .exchange()
+                .expectStatus().isNoContent();
+
+        Note updated = noteRepository.findById(saved.getId()).orElseThrow();
+        assertThat(updated.getBody()).isEqualTo("Updated body");
+        assertThat(updated.getDate()).isEqualTo(newDate);
+    }
+
+    @Test
+    void update_returns404_whenNoteNotFound() {
+        Engineer engineer = engineerRepository.save(buildEngineer());
+        UpdateNoteRequest request = new UpdateNoteRequest(
+                LocalDate.of(2024, 1, 1).atStartOfDay(ZoneOffset.UTC).toInstant(),
+                "Some body"
+        );
+
+        client.put().uri("/engineers/" + engineer.getId() + "/notes/" + UUID.randomUUID())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+    }
+
+    @Test
+    void update_returns404_whenEngineerNotFound() {
+        UpdateNoteRequest request = new UpdateNoteRequest(
+                LocalDate.of(2024, 1, 1).atStartOfDay(ZoneOffset.UTC).toInstant(),
+                "Some body"
+        );
+
+        client.put().uri("/engineers/" + UUID.randomUUID() + "/notes/" + UUID.randomUUID())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+    }
+
+    @Test
+    void update_returns400_whenDateIsNull() {
+        Engineer engineer = engineerRepository.save(buildEngineer());
+        Note saved = noteRepository.save(new Note(
+                engineer.getId(),
+                LocalDate.of(2024, 1, 1).atStartOfDay(ZoneOffset.UTC).toInstant(),
+                "Original"
+        ));
+        UpdateNoteRequest request = new UpdateNoteRequest(null, "Updated");
+
+        client.put().uri("/engineers/" + engineer.getId() + "/notes/" + saved.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .exchange()
+                .expectStatus().isBadRequest()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+    }
+
+    @Test
+    void update_returns400_whenBodyIsBlank() {
+        Engineer engineer = engineerRepository.save(buildEngineer());
+        Note saved = noteRepository.save(new Note(
+                engineer.getId(),
+                LocalDate.of(2024, 1, 1).atStartOfDay(ZoneOffset.UTC).toInstant(),
+                "Original"
+        ));
+        UpdateNoteRequest request = new UpdateNoteRequest(
+                LocalDate.of(2024, 1, 1).atStartOfDay(ZoneOffset.UTC).toInstant(),
+                ""
+        );
+
+        client.put().uri("/engineers/" + engineer.getId() + "/notes/" + saved.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .exchange()
+                .expectStatus().isBadRequest()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+    }
+
+    @Test
+    void update_returns400_whenDateIsMalformed() {
+        Engineer engineer = engineerRepository.save(buildEngineer());
+        Note saved = noteRepository.save(new Note(
+                engineer.getId(),
+                LocalDate.of(2024, 1, 1).atStartOfDay(ZoneOffset.UTC).toInstant(),
+                "Original"
+        ));
+
+        client.put().uri("/engineers/" + engineer.getId() + "/notes/" + saved.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Map.of("date", "not-a-timestamp", "body", "Updated"))
+                .exchange()
+                .expectStatus().isBadRequest()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+    }
+
+    // --- DELETE /engineers/{engineerId}/notes/{id} ---
+
+    @Test
+    void delete_returns204_andRemovesNote() {
+        Engineer engineer = engineerRepository.save(buildEngineer());
+        Note saved = noteRepository.save(new Note(
+                engineer.getId(),
+                LocalDate.of(2024, 1, 1).atStartOfDay(ZoneOffset.UTC).toInstant(),
+                "To be deleted"
+        ));
+
+        client.delete().uri("/engineers/" + engineer.getId() + "/notes/" + saved.getId())
+                .exchange()
+                .expectStatus().isNoContent();
+
+        assertThat(noteRepository.existsById(saved.getId())).isFalse();
+    }
+
+    @Test
+    void delete_returns404_whenNoteNotFound() {
+        Engineer engineer = engineerRepository.save(buildEngineer());
+
+        client.delete().uri("/engineers/" + engineer.getId() + "/notes/" + UUID.randomUUID())
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+    }
+
+    @Test
+    void delete_returns404_whenEngineerNotFound() {
+        client.delete().uri("/engineers/" + UUID.randomUUID() + "/notes/" + UUID.randomUUID())
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+    }
+
+    // --- Ownership mismatch ---
+
+    @Test
+    void getById_returns404_whenNoteDoesNotBelongToEngineer() {
+        Engineer engineer1 = engineerRepository.save(buildEngineer());
+        Engineer engineer2 = engineerRepository.save(buildEngineer());
+        Note noteForEngineer1 = noteRepository.save(new Note(
+                engineer1.getId(),
+                LocalDate.of(2024, 1, 1).atStartOfDay(ZoneOffset.UTC).toInstant(),
+                "Engineer 1 note"
+        ));
+
+        client.get().uri("/engineers/" + engineer2.getId() + "/notes/" + noteForEngineer1.getId())
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+    }
+
+    @Test
+    void update_returns404_whenNoteDoesNotBelongToEngineer() {
+        Engineer engineer1 = engineerRepository.save(buildEngineer());
+        Engineer engineer2 = engineerRepository.save(buildEngineer());
+        Instant originalDate = LocalDate.of(2024, 1, 1).atStartOfDay(ZoneOffset.UTC).toInstant();
+        Note noteForEngineer1 = noteRepository.save(new Note(engineer1.getId(), originalDate, "Engineer 1 note"));
+        UpdateNoteRequest request = new UpdateNoteRequest(
+                LocalDate.of(2024, 2, 1).atStartOfDay(ZoneOffset.UTC).toInstant(),
+                "Attempted update"
+        );
+
+        client.put().uri("/engineers/" + engineer2.getId() + "/notes/" + noteForEngineer1.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+
+        Note unchanged = noteRepository.findById(noteForEngineer1.getId()).orElseThrow();
+        assertThat(unchanged.getBody()).isEqualTo("Engineer 1 note");
+        assertThat(unchanged.getDate()).isEqualTo(originalDate);
+    }
+
+    @Test
+    void delete_returns404_whenNoteDoesNotBelongToEngineer() {
+        Engineer engineer1 = engineerRepository.save(buildEngineer());
+        Engineer engineer2 = engineerRepository.save(buildEngineer());
+        Note noteForEngineer1 = noteRepository.save(new Note(
+                engineer1.getId(),
+                LocalDate.of(2024, 1, 1).atStartOfDay(ZoneOffset.UTC).toInstant(),
+                "Engineer 1 note"
+        ));
+
+        client.delete().uri("/engineers/" + engineer2.getId() + "/notes/" + noteForEngineer1.getId())
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+
+        assertThat(noteRepository.existsById(noteForEngineer1.getId())).isTrue();
+    }
+
+    // --- Helpers ---
+
+    private Engineer buildEngineer() {
+        return new Engineer("Alice", EngineerLevel.ENGINEER_I, Squad.SQUAD_1,
+                LocalDate.of(2022, 6, 1), EmploymentType.INTERNAL, null, null);
+    }
+}


### PR DESCRIPTION
## Summary
- Implements full CRUD for 1:1 notes under `/engineers/{engineerId}/notes` (closes #3, depends on #2)
- `date` is stored as `LocalDate` in PostgreSQL and exposed as `Instant` in the Java API; incoming instants are normalised to UTC midnight on write via `InstantToLocalDateConverter`
- Notes are always returned ordered by date descending
- 404 is returned when the engineer or note is not found, including when a note is accessed via the wrong engineer's URL path (ownership enforcement)

## Key design decisions
- `ON DELETE CASCADE` on `notes.engineer_id` — deleting an engineer removes their notes at the DB level
- `ResourceNotFoundException` base class introduced so the `GlobalExceptionHandler` needs no changes when future entities are added
- `HttpMessageNotReadableException` (malformed JSON body) now returns 400 instead of 500

## Test plan
- [ ] 24 Testcontainers integration tests: all 5 endpoints × happy path, 404 (missing engineer), 404 (missing note), 400 (validation), ownership mismatch
- [ ] `update` mismatch test asserts DB state is unchanged after rejected request
- [ ] `delete` mismatch test asserts the note still exists after rejected delete
- [ ] Round-trip test confirms non-midnight instants are truncated to UTC midnight

🤖 Generated with [Claude Code](https://claude.com/claude-code)