### PR TITLE
feat: Feedback Note CRUD API (closes #4)

### DIFF
--- a/backend/src/main/java/io/anikoloutsos/manager_tools/exception/FeedbackNoteNotFoundException.java
+++ b/backend/src/main/java/io/anikoloutsos/manager_tools/exception/FeedbackNoteNotFoundException.java
@@ -1,0 +1,10 @@
+package io.anikoloutsos.manager_tools.exception;
+
+import java.util.UUID;
+
+public class FeedbackNoteNotFoundException extends ResourceNotFoundException {
+
+    public FeedbackNoteNotFoundException(UUID id) {
+        super("Feedback note not found with id: " + id);
+    }
+}

--- a/backend/src/main/java/io/anikoloutsos/manager_tools/feedbacknote/FeedbackNote.java
+++ b/backend/src/main/java/io/anikoloutsos/manager_tools/feedbacknote/FeedbackNote.java
@@ -1,0 +1,81 @@
+package io.anikoloutsos.manager_tools.feedbacknote;
+
+import io.anikoloutsos.manager_tools.note.InstantToLocalDateConverter;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "feedback_notes")
+public class FeedbackNote {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "engineer_id")
+    private UUID engineerId;
+
+    @Convert(converter = InstantToLocalDateConverter.class)
+    @Column(nullable = false)
+    private Instant date;
+
+    @Column
+    private String giver;
+
+    @Column(columnDefinition = "TEXT")
+    private String situation;
+
+    @Column(columnDefinition = "TEXT")
+    private String task;
+
+    @Column(columnDefinition = "TEXT")
+    private String action;
+
+    @Column(columnDefinition = "TEXT")
+    private String result;
+
+    protected FeedbackNote() {
+    }
+
+    public FeedbackNote(UUID engineerId, Instant date, String giver,
+                        String situation, String task, String action, String result) {
+        this.engineerId = engineerId;
+        this.date = date;
+        this.giver = giver;
+        this.situation = situation;
+        this.task = task;
+        this.action = action;
+        this.result = result;
+    }
+
+    public UUID getId() { return id; }
+
+    public UUID getEngineerId() { return engineerId; }
+    public void setEngineerId(UUID engineerId) { this.engineerId = engineerId; }
+
+    public Instant getDate() { return date; }
+    public void setDate(Instant date) { this.date = date; }
+
+    public String getGiver() { return giver; }
+    public void setGiver(String giver) { this.giver = giver; }
+
+    public String getSituation() { return situation; }
+    public void setSituation(String situation) { this.situation = situation; }
+
+    public String getTask() { return task; }
+    public void setTask(String task) { this.task = task; }
+
+    public String getAction() { return action; }
+    public void setAction(String action) { this.action = action; }
+
+    public String getResult() { return result; }
+    public void setResult(String result) { this.result = result; }
+}

--- a/backend/src/main/java/io/anikoloutsos/manager_tools/feedbacknote/FeedbackNoteController.java
+++ b/backend/src/main/java/io/anikoloutsos/manager_tools/feedbacknote/FeedbackNoteController.java
@@ -1,0 +1,61 @@
+package io.anikoloutsos.manager_tools.feedbacknote;
+
+import io.anikoloutsos.manager_tools.feedbacknote.dto.CreateFeedbackNoteRequest;
+import io.anikoloutsos.manager_tools.feedbacknote.dto.FeedbackNoteResponse;
+import io.anikoloutsos.manager_tools.feedbacknote.dto.UpdateFeedbackNoteRequest;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+public class FeedbackNoteController {
+
+    private final FeedbackNoteService service;
+
+    public FeedbackNoteController(FeedbackNoteService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/feedback-notes")
+    public List<FeedbackNoteResponse> getAll() {
+        return service.findAll();
+    }
+
+    @GetMapping("/feedback-notes/{id}")
+    public FeedbackNoteResponse getById(@PathVariable UUID id) {
+        return service.findById(id);
+    }
+
+    @GetMapping("/engineers/{engineerId}/feedback-notes")
+    public List<FeedbackNoteResponse> getByEngineerId(@PathVariable UUID engineerId) {
+        return service.findAllByEngineerId(engineerId);
+    }
+
+    @PostMapping("/feedback-notes")
+    @ResponseStatus(HttpStatus.CREATED)
+    public FeedbackNoteResponse create(@RequestBody @Valid CreateFeedbackNoteRequest request) {
+        return service.create(request);
+    }
+
+    @PutMapping("/feedback-notes/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void update(@PathVariable UUID id, @RequestBody @Valid UpdateFeedbackNoteRequest request) {
+        service.update(id, request);
+    }
+
+    @DeleteMapping("/feedback-notes/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable UUID id) {
+        service.delete(id);
+    }
+}

--- a/backend/src/main/java/io/anikoloutsos/manager_tools/feedbacknote/FeedbackNoteRepository.java
+++ b/backend/src/main/java/io/anikoloutsos/manager_tools/feedbacknote/FeedbackNoteRepository.java
@@ -1,0 +1,15 @@
+package io.anikoloutsos.manager_tools.feedbacknote;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface FeedbackNoteRepository extends JpaRepository<FeedbackNote, UUID> {
+
+    List<FeedbackNote> findAllByOrderByDateDesc();
+
+    List<FeedbackNote> findByEngineerIdOrderByDateDesc(UUID engineerId);
+}

--- a/backend/src/main/java/io/anikoloutsos/manager_tools/feedbacknote/FeedbackNoteService.java
+++ b/backend/src/main/java/io/anikoloutsos/manager_tools/feedbacknote/FeedbackNoteService.java
@@ -1,0 +1,88 @@
+package io.anikoloutsos.manager_tools.feedbacknote;
+
+import io.anikoloutsos.manager_tools.engineer.EngineerRepository;
+import io.anikoloutsos.manager_tools.exception.EngineerNotFoundException;
+import io.anikoloutsos.manager_tools.exception.FeedbackNoteNotFoundException;
+import io.anikoloutsos.manager_tools.feedbacknote.dto.CreateFeedbackNoteRequest;
+import io.anikoloutsos.manager_tools.feedbacknote.dto.FeedbackNoteResponse;
+import io.anikoloutsos.manager_tools.feedbacknote.dto.UpdateFeedbackNoteRequest;
+import io.anikoloutsos.manager_tools.note.InstantToLocalDateConverter;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@Transactional
+public class FeedbackNoteService {
+
+    private final FeedbackNoteRepository repository;
+    private final EngineerRepository engineerRepository;
+
+    public FeedbackNoteService(FeedbackNoteRepository repository, EngineerRepository engineerRepository) {
+        this.repository = repository;
+        this.engineerRepository = engineerRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<FeedbackNoteResponse> findAll() {
+        return repository.findAllByOrderByDateDesc().stream().map(this::toResponse).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<FeedbackNoteResponse> findAllByEngineerId(UUID engineerId) {
+        return repository.findByEngineerIdOrderByDateDesc(engineerId).stream().map(this::toResponse).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public FeedbackNoteResponse findById(UUID id) {
+        return toResponse(repository.findById(id).orElseThrow(() -> new FeedbackNoteNotFoundException(id)));
+    }
+
+    public FeedbackNoteResponse create(CreateFeedbackNoteRequest request) {
+        requireEngineerExistsIfPresent(request.engineerId());
+        FeedbackNote note = new FeedbackNote(
+                request.engineerId(),
+                InstantToLocalDateConverter.toUtcMidnight(request.date()),
+                request.giver(),
+                request.situation(),
+                request.task(),
+                request.action(),
+                request.result()
+        );
+        return toResponse(repository.save(note));
+    }
+
+    public void update(UUID id, UpdateFeedbackNoteRequest request) {
+        FeedbackNote note = repository.findById(id)
+                .orElseThrow(() -> new FeedbackNoteNotFoundException(id));
+        requireEngineerExistsIfPresent(request.engineerId());
+        note.setEngineerId(request.engineerId());
+        note.setDate(InstantToLocalDateConverter.toUtcMidnight(request.date()));
+        note.setGiver(request.giver());
+        note.setSituation(request.situation());
+        note.setTask(request.task());
+        note.setAction(request.action());
+        note.setResult(request.result());
+    }
+
+    public void delete(UUID id) {
+        FeedbackNote note = repository.findById(id)
+                .orElseThrow(() -> new FeedbackNoteNotFoundException(id));
+        repository.delete(note);
+    }
+
+    private void requireEngineerExistsIfPresent(UUID engineerId) {
+        if (engineerId != null && !engineerRepository.existsById(engineerId)) {
+            throw new EngineerNotFoundException(engineerId);
+        }
+    }
+
+    private FeedbackNoteResponse toResponse(FeedbackNote note) {
+        return new FeedbackNoteResponse(
+                note.getId(), note.getEngineerId(), note.getDate(), note.getGiver(),
+                note.getSituation(), note.getTask(), note.getAction(), note.getResult()
+        );
+    }
+}

--- a/backend/src/main/java/io/anikoloutsos/manager_tools/feedbacknote/dto/CreateFeedbackNoteRequest.java
+++ b/backend/src/main/java/io/anikoloutsos/manager_tools/feedbacknote/dto/CreateFeedbackNoteRequest.java
@@ -1,0 +1,29 @@
+package io.anikoloutsos.manager_tools.feedbacknote.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record CreateFeedbackNoteRequest(
+        UUID engineerId,
+        @NotNull Instant date,
+        String giver,
+        String situation,
+        String task,
+        String action,
+        String result
+) {
+
+    @JsonIgnore
+    @AssertTrue(message = "at least one of situation, task, action, result must be present")
+    public boolean isAtLeastOneStarFieldPresent() {
+        return hasText(situation) || hasText(task) || hasText(action) || hasText(result);
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/backend/src/main/java/io/anikoloutsos/manager_tools/feedbacknote/dto/FeedbackNoteResponse.java
+++ b/backend/src/main/java/io/anikoloutsos/manager_tools/feedbacknote/dto/FeedbackNoteResponse.java
@@ -1,0 +1,16 @@
+package io.anikoloutsos.manager_tools.feedbacknote.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record FeedbackNoteResponse(
+        UUID id,
+        UUID engineerId,
+        Instant date,
+        String giver,
+        String situation,
+        String task,
+        String action,
+        String result
+) {
+}

--- a/backend/src/main/java/io/anikoloutsos/manager_tools/feedbacknote/dto/UpdateFeedbackNoteRequest.java
+++ b/backend/src/main/java/io/anikoloutsos/manager_tools/feedbacknote/dto/UpdateFeedbackNoteRequest.java
@@ -1,0 +1,29 @@
+package io.anikoloutsos.manager_tools.feedbacknote.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record UpdateFeedbackNoteRequest(
+        UUID engineerId,
+        @NotNull Instant date,
+        String giver,
+        String situation,
+        String task,
+        String action,
+        String result
+) {
+
+    @JsonIgnore
+    @AssertTrue(message = "at least one of situation, task, action, result must be present")
+    public boolean isAtLeastOneStarFieldPresent() {
+        return hasText(situation) || hasText(task) || hasText(action) || hasText(result);
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/backend/src/main/resources/db/migration/V3__create_feedback_notes_table.sql
+++ b/backend/src/main/resources/db/migration/V3__create_feedback_notes_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE feedback_notes (
+    id          UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+    engineer_id UUID REFERENCES engineers(id) ON DELETE CASCADE,
+    date        DATE NOT NULL,
+    giver       VARCHAR(255),
+    situation   TEXT,
+    task        TEXT,
+    action      TEXT,
+    result      TEXT
+);
+
+CREATE INDEX idx_feedback_notes_engineer_id ON feedback_notes(engineer_id);
+CREATE INDEX idx_feedback_notes_date ON feedback_notes(date DESC);

--- a/backend/src/test/java/io/anikoloutsos/manager_tools/feedbacknote/FeedbackNoteControllerIT.java
+++ b/backend/src/test/java/io/anikoloutsos/manager_tools/feedbacknote/FeedbackNoteControllerIT.java
@@ -1,0 +1,500 @@
+package io.anikoloutsos.manager_tools.feedbacknote;
+
+import io.anikoloutsos.manager_tools.TestcontainersConfiguration;
+import io.anikoloutsos.manager_tools.engineer.Engineer;
+import io.anikoloutsos.manager_tools.engineer.EmploymentType;
+import io.anikoloutsos.manager_tools.engineer.EngineerLevel;
+import io.anikoloutsos.manager_tools.engineer.EngineerRepository;
+import io.anikoloutsos.manager_tools.engineer.Squad;
+import io.anikoloutsos.manager_tools.exception.ErrorResponse;
+import io.anikoloutsos.manager_tools.feedbacknote.dto.CreateFeedbackNoteRequest;
+import io.anikoloutsos.manager_tools.feedbacknote.dto.FeedbackNoteResponse;
+import io.anikoloutsos.manager_tools.feedbacknote.dto.UpdateFeedbackNoteRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.client.RestTestClient;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+class FeedbackNoteControllerIT {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private FeedbackNoteRepository feedbackNoteRepository;
+
+    @Autowired
+    private EngineerRepository engineerRepository;
+
+    private RestTestClient client;
+
+    @BeforeEach
+    void setUp() {
+        client = RestTestClient.bindToApplicationContext(context).build();
+        feedbackNoteRepository.deleteAll();
+        engineerRepository.deleteAll();
+    }
+
+    // --- GET /feedback-notes ---
+
+    @Test
+    void getAll_returnsEmptyList_whenNoFeedbackNotes() {
+        client.get().uri("/feedback-notes")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(FeedbackNoteResponse[].class)
+                .consumeWith(result -> assertThat(result.getResponseBody()).isEmpty());
+    }
+
+    @Test
+    void getAll_returnsFeedbackNotesOrderedByDateDescending() {
+        Instant older = dateAt(2024, 1, 1);
+        Instant newer = dateAt(2024, 6, 1);
+        feedbackNoteRepository.save(buildNote(null, older, "Older"));
+        feedbackNoteRepository.save(buildNote(null, newer, "Newer"));
+
+        client.get().uri("/feedback-notes")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(FeedbackNoteResponse[].class)
+                .consumeWith(result -> {
+                    FeedbackNoteResponse[] body = result.getResponseBody();
+                    assertThat(body).hasSize(2);
+                    assertThat(body[0].situation()).isEqualTo("Newer");
+                    assertThat(body[0].date()).isEqualTo(newer);
+                    assertThat(body[1].situation()).isEqualTo("Older");
+                    assertThat(body[1].date()).isEqualTo(older);
+                });
+    }
+
+    @Test
+    void getAll_includesNotesWithNullEngineerId() {
+        feedbackNoteRepository.save(buildNote(null, dateAt(2024, 2, 1), "Unlinked feedback"));
+
+        client.get().uri("/feedback-notes")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(FeedbackNoteResponse[].class)
+                .consumeWith(result -> {
+                    assertThat(result.getResponseBody()).hasSize(1);
+                    assertThat(result.getResponseBody()[0].engineerId()).isNull();
+                    assertThat(result.getResponseBody()[0].situation()).isEqualTo("Unlinked feedback");
+                });
+    }
+
+    // --- GET /feedback-notes/{id} ---
+
+    @Test
+    void getById_returnsFeedbackNote_whenFound() {
+        Engineer engineer = engineerRepository.save(buildEngineer());
+        Instant date = dateAt(2024, 3, 15);
+        FeedbackNote saved = feedbackNoteRepository.save(new FeedbackNote(
+                engineer.getId(), date, "Alice",
+                "During sprint review", "Present the roadmap",
+                "She walked the team through milestones", "Team aligned on priorities"
+        ));
+
+        client.get().uri("/feedback-notes/" + saved.getId())
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(FeedbackNoteResponse.class)
+                .consumeWith(result -> {
+                    FeedbackNoteResponse body = result.getResponseBody();
+                    assertThat(body.id()).isEqualTo(saved.getId());
+                    assertThat(body.engineerId()).isEqualTo(engineer.getId());
+                    assertThat(body.date()).isEqualTo(date);
+                    assertThat(body.giver()).isEqualTo("Alice");
+                    assertThat(body.situation()).isEqualTo("During sprint review");
+                    assertThat(body.task()).isEqualTo("Present the roadmap");
+                    assertThat(body.action()).isEqualTo("She walked the team through milestones");
+                    assertThat(body.result()).isEqualTo("Team aligned on priorities");
+                });
+    }
+
+    @Test
+    void getById_returns404_whenNotFound() {
+        client.get().uri("/feedback-notes/" + UUID.randomUUID())
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+    }
+
+    // --- GET /engineers/{engineerId}/feedback-notes ---
+
+    @Test
+    void getByEngineerId_returnsOnlyThatEngineersNotes_orderedByDateDesc() {
+        Engineer engineer1 = engineerRepository.save(buildEngineer());
+        Engineer engineer2 = engineerRepository.save(buildEngineer());
+        Instant older = dateAt(2024, 1, 1);
+        Instant newer = dateAt(2024, 5, 1);
+        feedbackNoteRepository.save(buildNote(engineer1.getId(), older, "E1 older"));
+        feedbackNoteRepository.save(buildNote(engineer1.getId(), newer, "E1 newer"));
+        feedbackNoteRepository.save(buildNote(engineer2.getId(), dateAt(2024, 3, 1), "E2 note"));
+        feedbackNoteRepository.save(buildNote(null, dateAt(2024, 4, 1), "Unlinked"));
+
+        client.get().uri("/engineers/" + engineer1.getId() + "/feedback-notes")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(FeedbackNoteResponse[].class)
+                .consumeWith(result -> {
+                    FeedbackNoteResponse[] body = result.getResponseBody();
+                    assertThat(body).hasSize(2);
+                    assertThat(body[0].situation()).isEqualTo("E1 newer");
+                    assertThat(body[1].situation()).isEqualTo("E1 older");
+                });
+    }
+
+    @Test
+    void getByEngineerId_returnsEmpty_whenEngineerHasNoNotes() {
+        Engineer engineer = engineerRepository.save(buildEngineer());
+
+        client.get().uri("/engineers/" + engineer.getId() + "/feedback-notes")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(FeedbackNoteResponse[].class)
+                .consumeWith(result -> assertThat(result.getResponseBody()).isEmpty());
+    }
+
+    // --- POST /feedback-notes ---
+
+    @Test
+    void create_returns201_withOnlySituation() {
+        Engineer engineer = engineerRepository.save(buildEngineer());
+        Instant date = dateAt(2024, 5, 10);
+        CreateFeedbackNoteRequest request = new CreateFeedbackNoteRequest(
+                engineer.getId(), date, "Alice", "Standup feedback", null, null, null
+        );
+
+        client.post().uri("/feedback-notes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .exchange()
+                .expectStatus().isCreated()
+                .expectBody(FeedbackNoteResponse.class)
+                .consumeWith(result -> {
+                    FeedbackNoteResponse body = result.getResponseBody();
+                    assertThat(body.id()).isNotNull();
+                    assertThat(body.engineerId()).isEqualTo(engineer.getId());
+                    assertThat(body.giver()).isEqualTo("Alice");
+                    assertThat(body.situation()).isEqualTo("Standup feedback");
+                    assertThat(body.task()).isNull();
+                    assertThat(body.action()).isNull();
+                    assertThat(body.result()).isNull();
+                });
+    }
+
+    @Test
+    void create_returns201_withAllStarFields() {
+        Engineer engineer = engineerRepository.save(buildEngineer());
+        CreateFeedbackNoteRequest request = new CreateFeedbackNoteRequest(
+                engineer.getId(), dateAt(2024, 5, 10), "Bob",
+                "S", "T", "A", "R"
+        );
+
+        client.post().uri("/feedback-notes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .exchange()
+                .expectStatus().isCreated()
+                .expectBody(FeedbackNoteResponse.class)
+                .consumeWith(result -> {
+                    FeedbackNoteResponse body = result.getResponseBody();
+                    assertThat(body.situation()).isEqualTo("S");
+                    assertThat(body.task()).isEqualTo("T");
+                    assertThat(body.action()).isEqualTo("A");
+                    assertThat(body.result()).isEqualTo("R");
+                });
+    }
+
+    @Test
+    void create_returns201_withNullEngineerId() {
+        CreateFeedbackNoteRequest request = new CreateFeedbackNoteRequest(
+                null, dateAt(2024, 5, 10), "Bob", null, null, "Helped a junior debug", null
+        );
+
+        client.post().uri("/feedback-notes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .exchange()
+                .expectStatus().isCreated()
+                .expectBody(FeedbackNoteResponse.class)
+                .consumeWith(result -> {
+                    assertThat(result.getResponseBody().engineerId()).isNull();
+                    assertThat(result.getResponseBody().action()).isEqualTo("Helped a junior debug");
+                });
+    }
+
+    @Test
+    void create_returns404_whenEngineerIdUnknown() {
+        CreateFeedbackNoteRequest request = new CreateFeedbackNoteRequest(
+                UUID.randomUUID(), dateAt(2024, 5, 10), null, "something", null, null, null
+        );
+
+        client.post().uri("/feedback-notes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+    }
+
+    @Test
+    void update_returns404_whenEngineerIdUnknown() {
+        FeedbackNote saved = feedbackNoteRepository.save(
+                buildNote(null, dateAt(2024, 1, 1), "original"));
+        UpdateFeedbackNoteRequest request = new UpdateFeedbackNoteRequest(
+                UUID.randomUUID(), dateAt(2024, 1, 1), null, "still valid", null, null, null
+        );
+
+        client.put().uri("/feedback-notes/" + saved.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+    }
+
+    @Test
+    void create_roundTrips_nonMidnightInstant_toUtcMidnight() {
+        Instant nonMidnight = LocalDate.of(2024, 5, 10).atTime(14, 30).toInstant(ZoneOffset.UTC);
+        Instant expectedMidnight = dateAt(2024, 5, 10);
+        CreateFeedbackNoteRequest request = new CreateFeedbackNoteRequest(
+                null, nonMidnight, null, "Mid-day", null, null, null
+        );
+
+        client.post().uri("/feedback-notes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .exchange()
+                .expectStatus().isCreated()
+                .expectBody(FeedbackNoteResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().date()).isEqualTo(expectedMidnight));
+    }
+
+    @Test
+    void create_returns400_whenAllStarFieldsAreBlank() {
+        CreateFeedbackNoteRequest request = new CreateFeedbackNoteRequest(
+                null, dateAt(2024, 5, 10), "Alice", "", "  ", null, null
+        );
+
+        client.post().uri("/feedback-notes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .exchange()
+                .expectStatus().isBadRequest()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+    }
+
+    @Test
+    void create_returns400_whenAllStarFieldsAreNull() {
+        CreateFeedbackNoteRequest request = new CreateFeedbackNoteRequest(
+                null, dateAt(2024, 5, 10), "Alice", null, null, null, null
+        );
+
+        client.post().uri("/feedback-notes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .exchange()
+                .expectStatus().isBadRequest()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+    }
+
+    @Test
+    void create_returns400_whenDateIsNull() {
+        CreateFeedbackNoteRequest request = new CreateFeedbackNoteRequest(
+                null, null, null, "something", null, null, null
+        );
+
+        client.post().uri("/feedback-notes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .exchange()
+                .expectStatus().isBadRequest()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+    }
+
+    @Test
+    void create_returns400_whenDateIsMalformed() {
+        Map<String, Object> body = new HashMap<>();
+        body.put("date", "not-a-timestamp");
+        body.put("situation", "something");
+
+        client.post().uri("/feedback-notes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(body)
+                .exchange()
+                .expectStatus().isBadRequest()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+    }
+
+    // --- PUT /feedback-notes/{id} ---
+
+    @Test
+    void update_returns204_andPersistsChanges() {
+        Engineer engineer = engineerRepository.save(buildEngineer());
+        FeedbackNote saved = feedbackNoteRepository.save(
+                buildNote(engineer.getId(), dateAt(2024, 1, 1), "Old situation"));
+
+        Instant newDate = dateAt(2024, 6, 1);
+        UpdateFeedbackNoteRequest request = new UpdateFeedbackNoteRequest(
+                engineer.getId(), newDate, "Carol",
+                "New situation", "New task", "New action", "New result"
+        );
+
+        client.put().uri("/feedback-notes/" + saved.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .exchange()
+                .expectStatus().isNoContent();
+
+        FeedbackNote updated = feedbackNoteRepository.findById(saved.getId()).orElseThrow();
+        assertThat(updated.getDate()).isEqualTo(newDate);
+        assertThat(updated.getGiver()).isEqualTo("Carol");
+        assertThat(updated.getSituation()).isEqualTo("New situation");
+        assertThat(updated.getTask()).isEqualTo("New task");
+        assertThat(updated.getAction()).isEqualTo("New action");
+        assertThat(updated.getResult()).isEqualTo("New result");
+    }
+
+    @Test
+    void update_canClearEngineerLink_bySettingEngineerIdToNull() {
+        Engineer engineer = engineerRepository.save(buildEngineer());
+        FeedbackNote saved = feedbackNoteRepository.save(
+                buildNote(engineer.getId(), dateAt(2024, 1, 1), "linked"));
+
+        UpdateFeedbackNoteRequest request = new UpdateFeedbackNoteRequest(
+                null, dateAt(2024, 1, 1), null, "linked", null, null, null
+        );
+
+        client.put().uri("/feedback-notes/" + saved.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .exchange()
+                .expectStatus().isNoContent();
+
+        assertThat(feedbackNoteRepository.findById(saved.getId()).orElseThrow().getEngineerId()).isNull();
+    }
+
+    @Test
+    void update_returns404_whenNotFound() {
+        UpdateFeedbackNoteRequest request = new UpdateFeedbackNoteRequest(
+                null, dateAt(2024, 1, 1), null, "s", null, null, null
+        );
+
+        client.put().uri("/feedback-notes/" + UUID.randomUUID())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+    }
+
+    @Test
+    void update_returns400_whenAllStarFieldsAreBlank() {
+        FeedbackNote saved = feedbackNoteRepository.save(
+                buildNote(null, dateAt(2024, 1, 1), "original"));
+
+        UpdateFeedbackNoteRequest request = new UpdateFeedbackNoteRequest(
+                null, dateAt(2024, 1, 1), "Alice", "", "   ", null, null
+        );
+
+        client.put().uri("/feedback-notes/" + saved.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .exchange()
+                .expectStatus().isBadRequest()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+    }
+
+    @Test
+    void update_returns400_whenDateIsNull() {
+        FeedbackNote saved = feedbackNoteRepository.save(
+                buildNote(null, dateAt(2024, 1, 1), "original"));
+        UpdateFeedbackNoteRequest request = new UpdateFeedbackNoteRequest(
+                null, null, null, "still valid STAR", null, null, null
+        );
+
+        client.put().uri("/feedback-notes/" + saved.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .exchange()
+                .expectStatus().isBadRequest()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+    }
+
+    // --- DELETE /feedback-notes/{id} ---
+
+    @Test
+    void delete_returns204_andRemovesFeedbackNote() {
+        FeedbackNote saved = feedbackNoteRepository.save(
+                buildNote(null, dateAt(2024, 1, 1), "to delete"));
+
+        client.delete().uri("/feedback-notes/" + saved.getId())
+                .exchange()
+                .expectStatus().isNoContent();
+
+        assertThat(feedbackNoteRepository.existsById(saved.getId())).isFalse();
+    }
+
+    @Test
+    void delete_returns404_whenNotFound() {
+        client.delete().uri("/feedback-notes/" + UUID.randomUUID())
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody(ErrorResponse.class)
+                .consumeWith(result -> assertThat(result.getResponseBody().message()).isNotBlank());
+    }
+
+    // --- CASCADE behavior ---
+
+    @Test
+    void deletingEngineer_cascadeDeletesTheirFeedbackNotes() {
+        Engineer engineer = engineerRepository.save(buildEngineer());
+        FeedbackNote saved = feedbackNoteRepository.save(
+                buildNote(engineer.getId(), dateAt(2024, 1, 1), "will cascade"));
+
+        engineerRepository.deleteById(engineer.getId());
+
+        assertThat(feedbackNoteRepository.existsById(saved.getId())).isFalse();
+    }
+
+    // --- Helpers ---
+
+    private static Instant dateAt(int year, int month, int day) {
+        return LocalDate.of(year, month, day).atStartOfDay(ZoneOffset.UTC).toInstant();
+    }
+
+    private static FeedbackNote buildNote(UUID engineerId, Instant date, String situation) {
+        return new FeedbackNote(engineerId, date, null, situation, null, null, null);
+    }
+
+    private static Engineer buildEngineer() {
+        return new Engineer("Alice", EngineerLevel.ENGINEER_I, Squad.SQUAD_1,
+                LocalDate.of(2022, 6, 1), EmploymentType.INTERNAL, null, null);
+    }
+}


### PR DESCRIPTION
## Summary
- New `feedback_notes` table (V3 migration) and `/feedback-notes` CRUD endpoints for STAR-structured feedback, optionally linked to an engineer
- Engineer link is validated when provided (404 on unknown id) and nullable; deleting an engineer cascades to their feedback notes
- Request validation enforces at least one of `situation`/`task`/`action`/`result` is non-blank; list endpoints return notes ordered by date descending

## Endpoints
- `GET /feedback-notes`
- `GET /feedback-notes/{id}`
- `GET /engineers/{engineerId}/feedback-notes`
- `POST /feedback-notes`
- `PUT /feedback-notes/{id}`
- `DELETE /feedback-notes/{id}`

## Test plan
- [x] `mvn test` green (65/65, including 25 new `FeedbackNoteControllerIT` tests)
- [x] Covers: happy paths, 404 paths, STAR non-empty rule, nullable engineerId, unknown engineerId → 404, non-midnight date normalization, engineer delete cascade, clearing engineer link on update
- [x] java-reviewer subagent: PASS (no CRITICAL/HIGH findings)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)